### PR TITLE
README: drop manual ChromeDriver install (Selenium >=4.7 handles it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ with in order to do your part.
 Install
 -------
 
-You'll need to install [ChromeDriver] before doing anything else. If you use
-Homebrew on OS X this is as easy as:
-
-    brew cask install chromedriver
-
-Then you'll want to install [Python 3] and:
+You'll want to install [Python 3] and then:
 
     pip3 install etudier
+
+étudier drives a Chrome browser, so you'll need [Chrome] installed. Selenium
+(>=4.7, already a dependency) downloads a matching [ChromeDriver] for you, so
+there's no separate driver to install. If an older chromedriver on your `PATH`
+doesn't match your installed Chrome, remove it and let Selenium manage it.
 
 Run
 ---
@@ -107,4 +107,5 @@ Features of HTML/D3 output
 [networkx]: https://networkx.github.io/
 [D3]: https://d3js.org/
 [Python 3]: https://www.python.org/downloads/
-[ChromeDriver]: https://sites.google.com/a/chromium.org/chromedriver/
+[Chrome]: https://www.google.com/chrome/
+[ChromeDriver]: https://developer.chrome.com/docs/chromedriver


### PR DESCRIPTION
Follow-up to #32. As discussed there, the README's manual `brew cask install chromedriver` step breaks first run when brew's driver out-majors your installed Chrome — and `selenium>=4.7` (already a dependency) resolves a matching driver on its own.

This drops the manual step, notes that Selenium handles the driver, and adds a one-line troubleshooting note for a stale chromedriver on `PATH`. Also refreshes the dead `[ChromeDriver]` link (the old `sites.google.com` page now redirects to a Google sign-in).

Docs only — no code changes.

Closes #32